### PR TITLE
Add Sepolia as testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ This repo includes deployed and verified contracts on Goerli so the front-end ca
 
 Once the `deploy` command is executed on any network the contracts config will be overwritten and you can start from scratch with your own deployments.
 
+#### Sepolia
+
+| Name                   | Address                                                                                                                       |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `PriceConsumerV3`      | [0xf37F9826f60870894190B5Ffe89138f3ef10079C](https://sepolia.etherscan.io/address/0xf37F9826f60870894190B5Ffe89138f3ef10079C) |
+| `APIConsumer`          | [0x8fEa7488314D44776C7960B3149258827B8ADa31](https://sepolia.etherscan.io/address/0x8fEa7488314D44776C7960B3149258827B8ADa31) |
+| `RandomNumberConsumer` | [0xBcFd34a46C2Da1E10568B4691ab2678cB24265db](https://sepolia.etherscan.io/address/0xBcFd34a46C2Da1E10568B4691ab2678cB24265db) |
+| `RandomSVG`            | [0xc055B4DA31b7895f60c6335276f47EbD817F98E1](https://sepolia.etherscan.io/address/0xc055B4DA31b7895f60c6335276f47EbD817F98E1) |
+
 #### Goerli
 
 | Name                   | Address                                                                                                                      |

--- a/packages/frontend/components/layout/Layout.tsx
+++ b/packages/frontend/components/layout/Layout.tsx
@@ -168,10 +168,12 @@ export const Layout = ({ children, customMeta }: LayoutProps): JSX.Element => {
                     {notification.transactionName}{' '}
                     {TRANSACTION_TYPE_TITLES[notification.type]}
                   </AlertTitle>
-                  <AlertDescription overflow="hidden">
-                    Transaction Hash:{' '}
-                    {truncateHash(notification.transaction.hash, 61)}
-                  </AlertDescription>
+                  {'transaction' in notification && (
+                    <AlertDescription overflow="hidden">
+                      Transaction Hash:
+                      {truncateHash(notification.transaction.hash, 61)}
+                    </AlertDescription>
+                  )}
                 </Box>
               </Alert>
             )

--- a/packages/frontend/components/vrf/RandomNFT/ExternalLink.tsx
+++ b/packages/frontend/components/vrf/RandomNFT/ExternalLink.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Badge, HStack, Link } from '@chakra-ui/react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
-import { useEthers } from '@usedapp/core'
+import { ChainId, useEthers } from '@usedapp/core'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useContractConfig } from '../../../hooks/useContractConfig'
-import { OpenSeaTestnet, OpenSeaUrl } from '../../../conf/config'
+import { OpenSeaUrl } from '../../../conf/config'
 
 /**
  * Prop Types
@@ -21,7 +21,7 @@ export function ExternalLink({ tokenId }: Props): JSX.Element {
 
   const contract = useContractConfig('RandomSVG')
 
-  const active = chainId === OpenSeaTestnet
+  const active = chainId === ChainId.Goerli
 
   const url = active
     ? `${OpenSeaUrl}/assets/${contract.address}/${tokenId}`
@@ -32,7 +32,7 @@ export function ExternalLink({ tokenId }: Props): JSX.Element {
       <Link href={url} isExternal>
         See on OpenSea Testnet Marketplace <ExternalLinkIcon mx="2px" />
       </Link>
-      {!active && <Badge>Goerli Only</Badge>}
+      {!active && <Badge>Goerli only</Badge>}
     </HStack>
   )
 }

--- a/packages/frontend/conf/config.ts
+++ b/packages/frontend/conf/config.ts
@@ -1,16 +1,24 @@
-import { ChainId, Config, Goerli, Mainnet, Hardhat } from '@usedapp/core'
+import {
+  ChainId,
+  Config,
+  Sepolia,
+  Goerli,
+  Mainnet,
+  Hardhat,
+} from '@usedapp/core'
 import deployedContracts from '../contracts/hardhat_contracts.json'
 
 const INFURA_KEY = process.env.NEXT_PUBLIC_INFURA_KEY
 
 const config: Config = {
-  readOnlyChainId: ChainId.Goerli,
+  readOnlyChainId: ChainId.Sepolia,
   readOnlyUrls: {
     [ChainId.Goerli]: `https://goerli.infura.io/v3/${INFURA_KEY}`,
+    [ChainId.Sepolia]: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
     [ChainId.Mainnet]: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
     [ChainId.Hardhat]: 'http://127.0.0.1:8545',
   },
-  networks: [Goerli, Hardhat],
+  networks: [Sepolia, Goerli, Hardhat],
   multicallAddresses: {
     [ChainId.Hardhat]:
       deployedContracts[ChainId.Hardhat][0].contracts.Multicall.address,
@@ -31,6 +39,5 @@ export enum Denominations {
 }
 
 export const OpenSeaUrl = 'https://testnets.opensea.io'
-export const OpenSeaTestnet = ChainId.Goerli
 
 export default config

--- a/packages/frontend/contracts/hardhat_contracts.json
+++ b/packages/frontend/contracts/hardhat_contracts.json
@@ -1145,7 +1145,7 @@
       "chainId": "31337",
       "contracts": {
         "APIConsumer": {
-          "address": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+          "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
           "abi": [
             {
               "inputs": [
@@ -1672,7 +1672,7 @@
           ]
         },
         "FeedRegistryConsumer": {
-          "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+          "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
           "abi": [
             {
               "inputs": [
@@ -2265,7 +2265,7 @@
           ]
         },
         "MockOracle": {
-          "address": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
+          "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
           "abi": [
             {
               "inputs": [
@@ -2648,7 +2648,7 @@
           ]
         },
         "PriceConsumerV3": {
-          "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+          "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
           "abi": [
             {
               "inputs": [
@@ -2677,7 +2677,7 @@
           ]
         },
         "RandomNumberConsumer": {
-          "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+          "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
           "abi": [
             {
               "inputs": [
@@ -2780,7 +2780,7 @@
           ]
         },
         "RandomSVG": {
-          "address": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+          "address": "0xf4B146FbA71F41E0592668ffbF264F1D186b2Ca8",
           "abi": [
             {
               "inputs": [
@@ -3553,7 +3553,7 @@
           ]
         },
         "VRFCoordinatorV2Mock": {
-          "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+          "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
           "abi": [
             {
               "inputs": [
@@ -4231,83 +4231,191 @@
             }
           ]
         },
-        "VRFV2WrapperConsumerBaseMock": {
-          "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+        "VRFV2Wrapper": {
+          "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
           "abi": [
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_link",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "_linkEthFeed",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "_coordinator",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "constructor"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "have",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "want",
+                  "type": "address"
+                }
+              ],
+              "name": "OnlyCoordinatorCanFulfill",
+              "type": "error"
+            },
             {
               "anonymous": false,
               "inputs": [
                 {
                   "indexed": true,
-                  "internalType": "bytes32",
-                  "name": "keyHash",
-                  "type": "bytes32"
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
                 },
                 {
-                  "indexed": false,
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                }
+              ],
+              "name": "OwnershipTransferRequested",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                }
+              ],
+              "name": "OwnershipTransferred",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
                   "internalType": "uint256",
                   "name": "requestId",
                   "type": "uint256"
                 },
                 {
-                  "indexed": false,
-                  "internalType": "uint256",
-                  "name": "preSeed",
-                  "type": "uint256"
-                },
-                {
-                  "indexed": true,
-                  "internalType": "uint64",
-                  "name": "subId",
-                  "type": "uint64"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint16",
-                  "name": "minimumRequestConfirmations",
-                  "type": "uint16"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint32",
-                  "name": "callbackGasLimit",
-                  "type": "uint32"
-                },
-                {
-                  "indexed": false,
-                  "internalType": "uint32",
-                  "name": "numWords",
-                  "type": "uint32"
-                },
-                {
                   "indexed": true,
                   "internalType": "address",
-                  "name": "sender",
+                  "name": "consumer",
                   "type": "address"
                 }
               ],
-              "name": "RandomWordsRequested",
+              "name": "WrapperFulfillmentFailed",
               "type": "event"
+            },
+            {
+              "inputs": [],
+              "name": "COORDINATOR",
+              "outputs": [
+                {
+                  "internalType": "contract ExtendedVRFCoordinatorV2Interface",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "LINK",
+              "outputs": [
+                {
+                  "internalType": "contract LinkTokenInterface",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "LINK_ETH_FEED",
+              "outputs": [
+                {
+                  "internalType": "contract AggregatorV3Interface",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "SUBSCRIPTION_ID",
+              "outputs": [
+                {
+                  "internalType": "uint64",
+                  "name": "",
+                  "type": "uint64"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "acceptOwnership",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
             },
             {
               "inputs": [
                 {
-                  "internalType": "bytes32",
-                  "name": "requestId",
-                  "type": "bytes32"
-                },
-                {
-                  "internalType": "uint256[]",
-                  "name": "randomness",
-                  "type": "uint256[]"
-                },
-                {
-                  "internalType": "address",
-                  "name": "consumerContract",
-                  "type": "address"
+                  "internalType": "uint32",
+                  "name": "_callbackGasLimit",
+                  "type": "uint32"
                 }
               ],
-              "name": "callBackWithRandomness",
+              "name": "calculateRequestPrice",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "disable",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "enable",
               "outputs": [],
               "stateMutability": "nonpayable",
               "type": "function"
@@ -4320,17 +4428,12 @@
                   "type": "uint32"
                 },
                 {
-                  "internalType": "uint16",
-                  "name": "_minimumRequestConfirmations",
-                  "type": "uint16"
-                },
-                {
-                  "internalType": "uint32",
-                  "name": "_numWords",
-                  "type": "uint32"
+                  "internalType": "uint256",
+                  "name": "_requestGasPriceWei",
+                  "type": "uint256"
                 }
               ],
-              "name": "requestRandomness",
+              "name": "estimateRequestPrice",
               "outputs": [
                 {
                   "internalType": "uint256",
@@ -4338,7 +4441,1404 @@
                   "type": "uint256"
                 }
               ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "getConfig",
+              "outputs": [
+                {
+                  "internalType": "int256",
+                  "name": "fallbackWeiPerUnitLink",
+                  "type": "int256"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "stalenessSeconds",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "fulfillmentFlatFeeLinkPPM",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "wrapperGasOverhead",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "coordinatorGasOverhead",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "wrapperPremiumPercentage",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "keyHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "maxNumWords",
+                  "type": "uint8"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "lastRequestId",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_sender",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "_amount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "_data",
+                  "type": "bytes"
+                }
+              ],
+              "name": "onTokenTransfer",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "owner",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "randomWords",
+                  "type": "uint256[]"
+                }
+              ],
+              "name": "rawFulfillRandomWords",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "s_callbacks",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "callbackAddress",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "callbackGasLimit",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "requestGasPrice",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "int256",
+                  "name": "requestWeiPerUnitLink",
+                  "type": "int256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "juelsPaid",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "s_configured",
+              "outputs": [
+                {
+                  "internalType": "bool",
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "s_disabled",
+              "outputs": [
+                {
+                  "internalType": "bool",
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint32",
+                  "name": "_wrapperGasOverhead",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "_coordinatorGasOverhead",
+                  "type": "uint32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "_wrapperPremiumPercentage",
+                  "type": "uint8"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "_keyHash",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint8",
+                  "name": "_maxNumWords",
+                  "type": "uint8"
+                }
+              ],
+              "name": "setConfig",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                }
+              ],
+              "name": "transferOwnership",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "typeAndVersion",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
               "stateMutability": "pure",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_recipient",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "_amount",
+                  "type": "uint256"
+                }
+              ],
+              "name": "withdraw",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "11155111": [
+    {
+      "name": "sepolia",
+      "chainId": "11155111",
+      "contracts": {
+        "APIConsumer": {
+          "address": "0x8fEa7488314D44776C7960B3149258827B8ADa31",
+          "abi": [
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_oracle",
+                  "type": "address"
+                },
+                {
+                  "internalType": "string",
+                  "name": "_jobId",
+                  "type": "string"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "_fee",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "address",
+                  "name": "_link",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "constructor"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "bytes32",
+                  "name": "id",
+                  "type": "bytes32"
+                }
+              ],
+              "name": "ChainlinkCancelled",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "bytes32",
+                  "name": "id",
+                  "type": "bytes32"
+                }
+              ],
+              "name": "ChainlinkFulfilled",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "bytes32",
+                  "name": "id",
+                  "type": "bytes32"
+                }
+              ],
+              "name": "ChainlinkRequested",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "previousOwner",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "newOwner",
+                  "type": "address"
+                }
+              ],
+              "name": "OwnershipTransferred",
+              "type": "event"
+            },
+            {
+              "inputs": [],
+              "name": "data",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "bytes32",
+                  "name": "_requestId",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "_data",
+                  "type": "uint256"
+                }
+              ],
+              "name": "fulfill",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "isOwner",
+              "outputs": [
+                {
+                  "internalType": "bool",
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "owner",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "string",
+                  "name": "url",
+                  "type": "string"
+                },
+                {
+                  "internalType": "string",
+                  "name": "path",
+                  "type": "string"
+                },
+                {
+                  "internalType": "int256",
+                  "name": "timesAmount",
+                  "type": "int256"
+                }
+              ],
+              "name": "requestData",
+              "outputs": [
+                {
+                  "internalType": "bytes32",
+                  "name": "requestId",
+                  "type": "bytes32"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "string",
+                  "name": "source",
+                  "type": "string"
+                }
+              ],
+              "name": "stringToBytes32",
+              "outputs": [
+                {
+                  "internalType": "bytes32",
+                  "name": "result",
+                  "type": "bytes32"
+                }
+              ],
+              "stateMutability": "pure",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "text",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "newOwner",
+                  "type": "address"
+                }
+              ],
+              "name": "transferOwnership",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "withdrawLink",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            }
+          ]
+        },
+        "PriceConsumerV3": {
+          "address": "0xf37F9826f60870894190B5Ffe89138f3ef10079C",
+          "abi": [
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_priceFeed",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "constructor"
+            },
+            {
+              "inputs": [],
+              "name": "getLatestPrice",
+              "outputs": [
+                {
+                  "internalType": "int256",
+                  "name": "",
+                  "type": "int256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            }
+          ]
+        },
+        "RandomNumberConsumer": {
+          "address": "0xBcFd34a46C2Da1E10568B4691ab2678cB24265db",
+          "abi": [
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_wrapperAddress",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "_link",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "_callbackGasLimit",
+                  "type": "uint32"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "constructor"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": false,
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "FulfilledRandomness",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": false,
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "RequestedRandomness",
+              "type": "event"
+            },
+            {
+              "inputs": [],
+              "name": "getRandomNumber",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "randomResult",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "_requestId",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "_randomWords",
+                  "type": "uint256[]"
+                }
+              ],
+              "name": "rawFulfillRandomWords",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "withdrawLink",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            }
+          ]
+        },
+        "RandomSVG": {
+          "address": "0xc055B4DA31b7895f60c6335276f47EbD817F98E1",
+          "abi": [
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "_vrfCoordinatorV2",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint64",
+                  "name": "_vrfSubscriptionId",
+                  "type": "uint64"
+                },
+                {
+                  "internalType": "bytes32",
+                  "name": "_vrfGasLane",
+                  "type": "bytes32"
+                },
+                {
+                  "internalType": "uint32",
+                  "name": "_vrfCallbackGasLimit",
+                  "type": "uint32"
+                }
+              ],
+              "stateMutability": "nonpayable",
+              "type": "constructor"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "have",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "want",
+                  "type": "address"
+                }
+              ],
+              "name": "OnlyCoordinatorCanFulfill",
+              "type": "error"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "approved",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "Approval",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "operator",
+                  "type": "address"
+                },
+                {
+                  "indexed": false,
+                  "internalType": "bool",
+                  "name": "approved",
+                  "type": "bool"
+                }
+              ],
+              "name": "ApprovalForAll",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                },
+                {
+                  "indexed": false,
+                  "internalType": "string",
+                  "name": "tokenURI",
+                  "type": "string"
+                }
+              ],
+              "name": "CreatedRandomSVG",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                },
+                {
+                  "indexed": false,
+                  "internalType": "uint256",
+                  "name": "randomNumber",
+                  "type": "uint256"
+                }
+              ],
+              "name": "CreatedUnfinishedRandomSVG",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "previousOwner",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "newOwner",
+                  "type": "address"
+                }
+              ],
+              "name": "OwnershipTransferred",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "Transfer",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                },
+                {
+                  "indexed": true,
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "requestedRandomSVG",
+              "type": "event"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "approve",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                }
+              ],
+              "name": "balanceOf",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "colors",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "create",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "finishMint",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "string",
+                  "name": "imageURI",
+                  "type": "string"
+                }
+              ],
+              "name": "formatTokenURI",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "pure",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "_randomness",
+                  "type": "uint256"
+                }
+              ],
+              "name": "generatePath",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "pathSvg",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "_randomness",
+                  "type": "uint256"
+                }
+              ],
+              "name": "generatePathCommand",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "pathCommand",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "_randomness",
+                  "type": "uint256"
+                }
+              ],
+              "name": "generateSVG",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "finalSvg",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "getApproved",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "owner",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "operator",
+                  "type": "address"
+                }
+              ],
+              "name": "isApprovedForAll",
+              "outputs": [
+                {
+                  "internalType": "bool",
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "maxNumberOfPathCommands",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "maxNumberOfPaths",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "name",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "owner",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "ownerOf",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "pathCommands",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "requestId",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256[]",
+                  "name": "randomWords",
+                  "type": "uint256[]"
+                }
+              ],
+              "name": "rawFulfillRandomWords",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "renounceOwnership",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "requestIdToSender",
+              "outputs": [
+                {
+                  "internalType": "address",
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "requestIdToTokenId",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "safeTransferFrom",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "_data",
+                  "type": "bytes"
+                }
+              ],
+              "name": "safeTransferFrom",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "operator",
+                  "type": "address"
+                },
+                {
+                  "internalType": "bool",
+                  "name": "approved",
+                  "type": "bool"
+                }
+              ],
+              "name": "setApprovalForAll",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "size",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "bytes4",
+                  "name": "interfaceId",
+                  "type": "bytes4"
+                }
+              ],
+              "name": "supportsInterface",
+              "outputs": [
+                {
+                  "internalType": "bool",
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "string",
+                  "name": "svg",
+                  "type": "string"
+                }
+              ],
+              "name": "svgToImageURI",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "pure",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "symbol",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "tokenCounter",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "name": "tokenIdToRandomNumber",
+              "outputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "",
+                  "type": "uint256"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "tokenURI",
+              "outputs": [
+                {
+                  "internalType": "string",
+                  "name": "",
+                  "type": "string"
+                }
+              ],
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
+                },
+                {
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenId",
+                  "type": "uint256"
+                }
+              ],
+              "name": "transferFrom",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [
+                {
+                  "internalType": "address",
+                  "name": "newOwner",
+                  "type": "address"
+                }
+              ],
+              "name": "transferOwnership",
+              "outputs": [],
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "inputs": [],
+              "name": "withdraw",
+              "outputs": [],
+              "stateMutability": "payable",
               "type": "function"
             }
           ]

--- a/packages/frontend/hooks/useContract.ts
+++ b/packages/frontend/hooks/useContract.ts
@@ -2,6 +2,7 @@ import { useEthers } from '@usedapp/core'
 import { Contract, ethers } from 'ethers'
 import { useMemo } from 'react'
 import { useContractConfig } from './useContractConfig'
+import { JsonRpcProvider } from '@ethersproject/providers'
 
 export function useContract<T extends Contract = Contract>(
   name: string
@@ -13,6 +14,9 @@ export function useContract<T extends Contract = Contract>(
   return useMemo(() => {
     if (!library) return null
     if (!contract?.address) return null
+    if (!(library instanceof JsonRpcProvider)) {
+      return null
+    }
 
     return new ethers.Contract(
       contract.address,

--- a/packages/frontend/lib/connectors.ts
+++ b/packages/frontend/lib/connectors.ts
@@ -5,6 +5,7 @@ const INFURA_KEY = process.env.NEXT_PUBLIC_INFURA_KEY
 const RPC_URLS: { [chainId: number]: string } = {
   1: `https://mainnet.infura.io/v3/${INFURA_KEY}`,
   5: `https://goerli.infura.io/v3/${INFURA_KEY}`,
+  11155111: `https://sepolia.infura.io/v3/${INFURA_KEY}`,
 }
 export const walletconnect = new WalletConnectConnector({
   rpc: { 1: RPC_URLS[1], 5: RPC_URLS[5] },

--- a/packages/frontend/lib/utils.ts
+++ b/packages/frontend/lib/utils.ts
@@ -7,7 +7,7 @@ export function getErrorMessage(error: Error): string {
   if (error.message.includes("No injected provider available") ) {
     return 'No Ethereum browser extension detected, install MetaMask on desktop or visit from a dApp browser on mobile.'
   } else if (error.name === "ChainIdError") {
-    return "You're connected to an unsupported network. Please switch to Goerli."
+    return "You're connected to an unsupported network. Please switch to Goerli or Sepolia."
   } else if (
     error.message.includes("The user rejected the request") ||
     error.message.includes("User rejected the request")

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -30,7 +30,7 @@
     "@chakra-ui/react": "^2.2.4",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
-    "@usedapp/core": "1.1.3",
+    "@usedapp/core": "1.2.7",
     "@web3-react/core": "^6.1.9",
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "^6.2.13",

--- a/packages/hardhat/.env.example
+++ b/packages/hardhat/.env.example
@@ -1,4 +1,5 @@
 GOERLI_RPC_URL='https://goerli.infura.io/v3/your-api-key'
+SEPOLIA_RPC_URL='https://sepolia.infura.io/v3/your-api-key'
 ETHERSCAN_API_KEY='your etherscan api key'
 PRIVATE_KEY='your private key'
 MNEMONIC='your mnemonic'

--- a/packages/hardhat/contracts/APIConsumer.sol
+++ b/packages/hardhat/contracts/APIConsumer.sol
@@ -13,8 +13,8 @@ contract APIConsumer is ChainlinkClient, Ownable {
   uint256 private fee;
 
   /**
-   * Network: Goerli
-   * Oracle: 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7
+   * Network: Sepolia
+   * Oracle: 0x6090149792dAAeE9D1D568c9f9a6F6B46AA29eFD
    * Job ID: ca98366cc7314957b8c012c72f05aeeb
    * Fee: 0.1 LINK
    */
@@ -29,7 +29,7 @@ contract APIConsumer is ChainlinkClient, Ownable {
     } else {
       setChainlinkToken(_link);
     }
-    // oracle = 0xCC79157eb46F5624204f47AB42b3906cAA40eaB7;
+    // oracle = 0x6090149792dAAeE9D1D568c9f9a6F6B46AA29eFD;
     // jobId = "ca98366cc7314957b8c012c72f05aeeb";
     // fee = 0.1 * 10 ** 18; // 0.1 LINK
     oracle = _oracle;

--- a/packages/hardhat/contracts/PriceConsumerV3.sol
+++ b/packages/hardhat/contracts/PriceConsumerV3.sol
@@ -6,9 +6,9 @@ contract PriceConsumerV3 {
   AggregatorV3Interface internal priceFeed;
 
   /**
-   * Network: Goerli
+   * Network: Sepolia
    * Aggregator: ETH/USD
-   * Address: 0xD4a33860578De61DBAbDc8BFdb98FD742fA7028e
+   * Address: 0x694AA1769357215DE4FAC081bf1f309aDC325306
    */
   constructor(address _priceFeed) public {
     priceFeed = AggregatorV3Interface(_priceFeed);

--- a/packages/hardhat/contracts/RandomNumberConsumer.sol
+++ b/packages/hardhat/contracts/RandomNumberConsumer.sol
@@ -19,9 +19,9 @@ contract RandomNumberConsumer is VRFV2WrapperConsumerBase {
   /**
    * Constructor inherits VRFConsumerBase
    *
-   * Network: Goerli
-   * Chainlink VRF Wrapper address:     0x708701a1DfF4f478de54383E49a627eD4852C816
-   * LINK token address:                0x326C977E6efc84E512bB9C30f76E30c160eD06FB
+   * Network: Sepolia
+   * Chainlink VRF Wrapper address:     0xab18414CD93297B0d12ac29E63Ca20f515b3DB46
+   * LINK token address:                0x779877A7B0D9E8603169DdbD7836e478b4624789
    */
   constructor(
     address _wrapperAddress,

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -1,13 +1,13 @@
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 import '@nomiclabs/hardhat-etherscan'
-import '@appliedblockchain/chainlink-plugins-fund-link'
 import '@typechain/hardhat'
 import 'hardhat-deploy'
 import 'dotenv/config'
 import { task } from 'hardhat/config'
 import './tasks/withdraw-link'
 import './tasks/accounts'
+import './tasks/fund-link'
 import { HardhatUserConfig } from 'hardhat/types'
 import 'solidity-coverage'
 
@@ -26,6 +26,10 @@ task('accounts', 'Prints the list of accounts', async (_args, hre) => {
 
 const GOERLI_RPC_URL =
   process.env.GOERLI_RPC_URL || 'https://goerli.infura.io/v3/your-api-key'
+
+const SEPOLIA_RPC_URL =
+  process.env.SEPOLIA_RPC_URL || 'https://sepolia.infura.io/v3/your-api-key'
+
 const MNEMONIC = process.env.MNEMONIC || 'your mnemonic'
 const ETHERSCAN_API_KEY =
   process.env.ETHERSCAN_API_KEY || 'Your etherscan API key'
@@ -39,10 +43,21 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {},
     localhost: {
-      url: 'http://localhost:8545',
+      chainId: 31337,
+      url: 'http://127.0.0.1:8545/',
     },
     goerli: {
+      chainId: 5,
       url: GOERLI_RPC_URL,
+      // accounts: [PRIVATE_KEY],
+      accounts: {
+        mnemonic: MNEMONIC,
+      },
+      saveDeployments: true,
+    },
+    sepolia: {
+      chainId: 11155111,
+      url: SEPOLIA_RPC_URL,
       // accounts: [PRIVATE_KEY],
       accounts: {
         mnemonic: MNEMONIC,

--- a/packages/hardhat/helper-hardhat-config.ts
+++ b/packages/hardhat/helper-hardhat-config.ts
@@ -13,7 +13,7 @@ export const networkConfig: Record<
       randomNumberConsumer: string
       randomSVG: string
     }
-    keyHash: string
+    keyHash?: string
     oracle?: string
     jobId: string
     fee: string
@@ -50,6 +50,24 @@ export const networkConfig: Record<
     keyHash:
       '0x0476f9a745b61ea5c0ab224d3a6e4c99f0b02fce4da01143a4f70aa80ae76e8a',
     oracle: '0xCC79157eb46F5624204f47AB42b3906cAA40eaB7',
+    jobId: 'ca98366cc7314957b8c012c72f05aeeb',
+    fee: '100000000000000000',
+    fundAmount: '5000000000000000000',
+  },
+  '11155111': {
+    name: 'sepolia',
+    linkToken: '0x779877A7B0D9E8603169DdbD7836e478b4624789',
+    ethUsdPriceFeed: '0x694AA1769357215DE4FAC081bf1f309aDC325306',
+    wrapperAddress: '0xab18414CD93297B0d12ac29E63Ca20f515b3DB46',
+    vrfCoordinatorV2: '0x8103B0A8A00be2DDC778e6e7eaa21791Cd364625',
+    vrfSubscriptionId: '0',
+    vrfGasLane:
+      '0x474e34a077df58807dbe9c96d3c009b23b3c6d0cce433e59bbf5b34f823bc56c',
+    vrfCallbackGasLimit: {
+      randomNumberConsumer: '150000',
+      randomSVG: '200000',
+    },
+    oracle: '0x6090149792dAAeE9D1D568c9f9a6F6B46AA29eFD',
     jobId: 'ca98366cc7314957b8c012c72f05aeeb',
     fee: '100000000000000000',
     fundAmount: '5000000000000000000',

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@appliedblockchain/chainlink-contracts": "^0.0.4",
-    "@appliedblockchain/chainlink-plugins-fund-link": "^0.0.3",
     "@chainlink/contracts": "^0.4.2",
     "@chainlink/token": "^1.1.0",
     "@nomiclabs/hardhat-ethers": "^2.1.0",

--- a/packages/hardhat/tasks/fund-link.ts
+++ b/packages/hardhat/tasks/fund-link.ts
@@ -1,0 +1,59 @@
+import { BigNumber } from 'ethers'
+import { networkConfig } from '../helper-hardhat-config'
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment, TaskArguments } from 'hardhat/types'
+
+task('fund-link', 'Transfer LINK tokens to a recipient')
+  .addParam(
+    'contract',
+    'The address of the EOA or contract account that will receive your LINK tokens'
+  )
+  .addParam('amount', 'Amount in Juels. 1LINK=10**18 JUELS')
+  .addOptionalParam('linkAddress', 'Set the LINK token address')
+  .setAction(
+    async (taskArgs: TaskArguments, hre: HardhatRuntimeEnvironment) => {
+      const { contract: recipientAddress, amount } = taskArgs
+      const networkId = hre.network.config.chainId
+
+      if (!networkId) return
+
+      //Get signer information
+      const accounts = await hre.ethers.getSigners()
+      const signer = accounts[0]
+
+      const linkTokenAddress =
+        networkConfig[networkId]['linkToken'] || taskArgs.linkAddress
+      const LinkToken = await hre.ethers.getContractFactory('LinkToken')
+      const linkTokenContract = await LinkToken.attach(linkTokenAddress)
+
+      const balance = await linkTokenContract.balanceOf(signer.address)
+      console.log(
+        `LINK balance of sender ${
+          signer.address
+        } is + ${hre.ethers.utils.formatEther(balance)}`
+      )
+      const amountBN = BigNumber.from(amount)
+      if (balance.gte(amountBN)) {
+        const result = await linkTokenContract.transfer(
+          recipientAddress,
+          amount
+        )
+        await result.wait()
+        console.log(
+          `${hre.ethers.utils.formatEther(
+            amountBN
+          )} LINK were sent from sender ${
+            signer.address
+          } to ${recipientAddress}.Transaction Hash: ${result.hash}`
+        )
+      } else {
+        console.log(
+          `Sender doesn't have enough LINK. Current balance is ${hre.ethers.utils.formatEther(
+            balance
+          )} LINK and transfer amount is ${hre.ethers.utils.formatEther(
+            amount
+          )} LINK`
+        )
+      }
+    }
+  )

--- a/packages/hardhat/test/unit/APIConsumer.test.ts
+++ b/packages/hardhat/test/unit/APIConsumer.test.ts
@@ -29,11 +29,8 @@ skip
       )) as APIConsumer
 
       if (await autoFundCheck(apiConsumer.address, chainId, linkTokenAddress)) {
-        await run('fund-link', {
-          contract: apiConsumer.address,
-          linkaddress: linkTokenAddress,
-          fundamount: networkConfig[chainId].fundAmount,
-        })
+        const fundAmount = networkConfig[chainId]['fundAmount']
+        await linkToken.transfer(apiConsumer.address, fundAmount)
       }
     })
 

--- a/packages/hardhat/test/unit/RandomNumberConsumer.test.ts
+++ b/packages/hardhat/test/unit/RandomNumberConsumer.test.ts
@@ -35,11 +35,8 @@ skip
           linkTokenAddress
         )
       ) {
-        await run('fund-link', {
-          contract: randomNumberConsumer.address,
-          linkaddress: linkTokenAddress,
-          fundamount: networkConfig[chainId].fundAmount,
-        })
+        const fundAmount = networkConfig[chainId]['fundAmount']
+        await linkToken.transfer(randomNumberConsumer.address, fundAmount)
       }
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2176,10 +2176,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
   integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
 
-"@metamask/detect-provider@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.2.0.tgz#3667a7531f2a682e3c3a43eaf3a1958bdb42a696"
-  integrity sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==
+"@metamask/detect-provider@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-2.0.0.tgz#4bc2795e5e6f7d8b84b2e845058d2f222c99917d"
+  integrity sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==
 
 "@metamask/eth-sig-util@^4.0.0":
   version "4.0.1"
@@ -3179,12 +3179,12 @@
   resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.30.tgz#2103ca23b8007c59ec71718d34cdc97861c409e5"
   integrity sha512-HwY2VvkQ8lNR6ks5NqQfAtg+4IZqz3KV1T8d2DlI8emIn9uMmaoFbIOg0nzjqAVKKnZSbMTRRtUoAh6mmjRvog==
 
-"@usedapp/core@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@usedapp/core/-/core-1.1.3.tgz#04f087edd96b5a5ec9726ba7fa278a6e68f5b937"
-  integrity sha512-2hWzZ9oCsfgzN8Ewu3of2JuWuiFfBUtSY4b+dz3YygZcx1D48IxjyUO3+VjxVbE5eQAYSjfnA6WVMDIBZ+K5zQ==
+"@usedapp/core@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@usedapp/core/-/core-1.2.7.tgz#c1560ce2577a518de6ed367f7cddbe48e6d17127"
+  integrity sha512-izqa9eXmMeqLq9vg1bX4xU8LOFDIlyfwQnHNuaYM1QuJ2IU3cRSBjXbcahzGZS+aUgW2ue3/wNmOZf20OWZhYA==
   dependencies:
-    "@metamask/detect-provider" "^1.2.0"
+    "@metamask/detect-provider" "^2.0.0"
     "@uniswap/token-lists" "^1.0.0-beta.27"
     fetch-mock "^9.11.0"
     lodash.merge "^4.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -221,7 +221,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@appliedblockchain/chainlink-contracts@0.0.4", "@appliedblockchain/chainlink-contracts@^0.0.4":
+"@appliedblockchain/chainlink-contracts@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@appliedblockchain/chainlink-contracts/-/chainlink-contracts-0.0.4.tgz#ee65494d18075a6c286c776f1201d01ed7bb6cd7"
   integrity sha512-TdgNdKoxJcFqatXW3+WquvVdwAU2eMe4yY460yxUM5b4Wxigo5+uxmSvGmBrld6I1gHe0ObPqqQMIJxnegtYGA==
@@ -229,14 +229,6 @@
     "@chainlink/contracts" "^0.1.9"
     "@chainlink/test-helpers" "0.0.5"
     "@chainlink/token" "^1.1.0"
-
-"@appliedblockchain/chainlink-plugins-fund-link@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@appliedblockchain/chainlink-plugins-fund-link/-/chainlink-plugins-fund-link-0.0.3.tgz#af3e0204cfc1570b17beb5fa92b131194ae8f1ef"
-  integrity sha512-npqEa6APijsjr2F/ZXCP399lXSOX8LwvNr7/dickx0G3V8vQ3GIiRDX1NueBPmx9O5i40V6nKNFZ3WWWzmvL9g==
-  dependencies:
-    "@appliedblockchain/chainlink-contracts" "0.0.4"
-    "@nomiclabs/hardhat-ethers" "^2.0.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -2361,7 +2353,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@nomiclabs/hardhat-ethers@^2.0.2", "@nomiclabs/hardhat-ethers@^2.1.0":
+"@nomiclabs/hardhat-ethers@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.1.0.tgz#9b7dc94d669ad9dc286b94f6f2f1513118c7027b"
   integrity sha512-vlW90etB3675QWG7tMrHaDoTa7ymMB7irM4DAQ98g8zJoe9YqEggeDnbO6v5b+BLth/ty4vN6Ko/kaqRN1krHw==


### PR DESCRIPTION
- Adds new contracts to Readme.md
- Adds Sepolia in frontend's network errors
- Adds Sepolia in usedapp's config file
- Adds newly deployed contractс to hardhat_contracts.json
- Update usedapp's version to 1.2.7 because older version doesn't support Sepolia
- Updates hardhat's plugin that funds link with a forked repository that supports Sepolia
- Updates contracts comments with new contract addresses
- Adds Sepolia network to hardhat config file
- Updates helper hardhat config file with Sepolia addresses
- New yarn.lock file
- Changes to `Layout.tsx` and `ExternalLink.tsx` because we have to narrow down union types to eliminate eslint errors. Building the app fails otherwise. 

resolves #134 